### PR TITLE
Fix custom token in BAccountDetails.m

### DIFF
--- a/ChatSDKCore/Classes/BAccountDetails.m
+++ b/ChatSDKCore/Classes/BAccountDetails.m
@@ -52,6 +52,7 @@
 +(id) token: (NSString *) token {
     BAccountDetails * details = [self new];
     details.type = bAccountTypeCustom;
+    details.token = token;
     return details;
 }
 


### PR DESCRIPTION
When attempting login with a custom token, there is a NSInvalidArgumentException because the token field is never assigned in the new BAccountDetails object.