### PR TITLE
Thread image functionality

### DIFF
--- a/ChatSDKCore/Classes/Entities/PThread_.h
+++ b/ChatSDKCore/Classes/Entities/PThread_.h
@@ -104,5 +104,17 @@ typedef enum {
 -(UIImage *)imageForThread;
 -(NSDate *) orderDate;
 
+-(RXPromise *) loadThreadImage: (BOOL) force;
+-(RXPromise *) loadThreadThumbnail: (BOOL) force;
+
+-(void) setMetaDictionary: (NSDictionary *) dict;
+-(NSDictionary *) metaDictionary;
+
+-(void) setImage: (NSData *) image;
+-(NSData *) image;
+
+-(void) setThumbnail: (NSData *) thumbnail;
+-(NSData *) thumbnail;
+
 @end
 

--- a/ChatSDKCore/Classes/Handlers/Abstract/BAbstractCoreHandler.m
+++ b/ChatSDKCore/Classes/Handlers/Abstract/BAbstractCoreHandler.m
@@ -195,6 +195,15 @@
  * Register block to:
  * - Handle thread creation
  */
+
+-(RXPromise *) createThreadWithUsers: (NSArray *)users
+                                name: (NSString *)name
+                               image: (NSString *)imageUrl
+                           thumbnail: (NSString *)thumbnailUrl
+                       threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {
+    assert(NO);
+}
+
 -(RXPromise *) createThreadWithUsers: (NSArray *) users
                                 name: (NSString *) name
                        threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {

--- a/ChatSDKCore/Classes/Interfaces/PCoreHandler.h
+++ b/ChatSDKCore/Classes/Interfaces/PCoreHandler.h
@@ -56,6 +56,12 @@
  * Register block to:
  * - Handle thread creation
  */
+-(RXPromise *) createThreadWithUsers: (NSArray *)users
+                                name: (NSString *)name
+                               image: (NSString *)imageUrl
+                           thumbnail: (NSString *)thumbnailUrl
+                       threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated;
+
 -(RXPromise *) createThreadWithUsers: (NSArray *) users
                                 name: (NSString *) name
                        threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated;

--- a/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/.xccurrentversion
+++ b/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>DataModel v012.xcdatamodel</string>
+	<string>DataModel v013.xcdatamodel</string>
 </dict>
 </plist>

--- a/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/DataModel v013.xcdatamodel/contents
+++ b/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/DataModel v013.xcdatamodel/contents
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13772" systemVersion="17C88" minimumToolsVersion="Xcode 4.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="CDGroup" representedClassName="CDGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="userConnections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUserConnection" inverseName="groups" inverseEntity="CDUserConnection" syncable="YES"/>
+    </entity>
+    <entity name="CDMessage" representedClassName="CDMessage" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="delivered" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dirty" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="entityID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="flagged" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="placeholder" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="read" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="resource" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="resourcePath" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="thread" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDThread" inverseName="messages" inverseEntity="CDThread" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDUser" inverseName="messages" inverseEntity="CDUser" syncable="YES"/>
+    </entity>
+    <entity name="CDThread" representedClassName="CDThread" syncable="YES">
+        <attribute name="apiKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="creatorEntityID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="deleted_" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dirty" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="entityID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasUnreadMessages" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="image" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="lastMessageAdded" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="rootKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="thumbnail" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="creator" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDUser" inverseName="threadsCreated" inverseEntity="CDUser" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDMessage" inverseName="thread" inverseEntity="CDMessage" syncable="YES"/>
+        <relationship name="users" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUser" inverseName="threads" inverseEntity="CDUser" syncable="YES"/>
+    </entity>
+    <entity name="CDUser" representedClassName="CDUser" syncable="YES">
+        <attribute name="authenticationType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dirty" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="entityID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="image" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="lastOnline" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="messageColor" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="online" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="thumbnail" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <relationship name="linkedAccounts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUserAccount" inverseName="user" inverseEntity="CDUserAccount" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDMessage" inverseName="user" inverseEntity="CDMessage" syncable="YES"/>
+        <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDThread" inverseName="users" inverseEntity="CDThread" syncable="YES"/>
+        <relationship name="threadsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDThread" inverseName="creator" inverseEntity="CDThread" syncable="YES"/>
+        <relationship name="userConnections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUserConnection" inverseName="owner" inverseEntity="CDUserConnection" syncable="YES"/>
+    </entity>
+    <entity name="CDUserAccount" representedClassName="CDUserAccount" syncable="YES">
+        <attribute name="token" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDUser" inverseName="linkedAccounts" inverseEntity="CDUser" syncable="YES"/>
+    </entity>
+    <entity name="CDUserConnection" representedClassName="CDUserConnection" syncable="YES">
+        <attribute name="entityID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="groups" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDGroup" inverseName="userConnections" inverseEntity="CDGroup" syncable="YES"/>
+        <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDUser" inverseName="userConnections" inverseEntity="CDUser" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="CDGroup" positionX="-747" positionY="-387" width="128" height="73"/>
+        <element name="CDMessage" positionX="-225" positionY="99" width="128" height="270"/>
+        <element name="CDThread" positionX="-236" positionY="-252" width="128" height="300"/>
+        <element name="CDUser" positionX="-693" positionY="-268" width="128" height="283"/>
+        <element name="CDUserAccount" positionX="-333" positionY="-396" width="128" height="88"/>
+        <element name="CDUserConnection" positionX="-945" positionY="-271" width="128" height="118"/>
+    </elements>
+</model>

--- a/ChatSDKCoreData/Classes/Entities/CDThread+CoreDataProperties.h
+++ b/ChatSDKCoreData/Classes/Entities/CDThread+CoreDataProperties.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, retain) NSSet<CDMessage *> *messages;
 @property (nullable, nonatomic, retain) NSSet<CDUser *> *users;
 
+@property (nullable, nonatomic, retain) NSData *image;
+@property (nullable, nonatomic, retain) NSData *thumbnail;
+
 @end
 
 @interface CDThread (CoreDataGeneratedAccessors)

--- a/ChatSDKCoreData/Classes/Entities/CDThread+CoreDataProperties.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread+CoreDataProperties.m
@@ -29,4 +29,7 @@
 @dynamic messages;
 @dynamic users;
 
+@dynamic image;
+@dynamic thumbnail;
+
 @end

--- a/ChatSDKCoreData/Classes/Entities/CDThread.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread.m
@@ -197,6 +197,7 @@
 // TODO: Move this to UI module
 - (UIImage *)imageForThread {
     
+    // If the thread has an image set then use this instead of a custom image
     if (self.thumbnail) {
         return [UIImage imageWithData:self.thumbnail];
     }

--- a/ChatSDKFirebaseAdapter/Classes/Firebase/CCThreadWrapper.m
+++ b/ChatSDKFirebaseAdapter/Classes/Firebase/CCThreadWrapper.m
@@ -478,6 +478,7 @@
     
     NSDictionary * meta = value[b_Meta];
     if (meta) {
+        // We don't need to access this when it returns - only need it to set the images if they are not already set
         [self deserializeMeta:meta];
     }
 }

--- a/ChatSDKFirebaseAdapter/Classes/Handlers/BFirebaseCoreHandler.m
+++ b/ChatSDKFirebaseAdapter/Classes/Handlers/BFirebaseCoreHandler.m
@@ -73,7 +73,7 @@
     return threads;
 }
 
--(RXPromise *) createThreadWithUsers: (NSArray *) users name: (NSString *) name threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {
+-(RXPromise *) createThreadWithUsers: (NSArray *) users name: (NSString *) name image: (NSString *)imageUrl thumbnail: (NSString *)thumbnailUrl threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {
     
     id<PUser> currentUser = self.currentUserModel;
     
@@ -129,6 +129,9 @@
     threadModel.type = usersToAdd.count == 2 ? @(bThreadType1to1) : @(bThreadTypePrivateGroup);
     threadModel.name = name;
     
+    [threadModel setMetaString:imageUrl forKey:bPictureURLKey];
+    [threadModel setMetaString:thumbnailUrl forKey:bPictureURLThumbnailKey];
+    
     CCThreadWrapper * thread = [CCThreadWrapper threadWithModel:threadModel];
     
     return [thread push].thenOnMain(^id(id<PThread> thread) {
@@ -149,10 +152,13 @@
     });
 }
 
+-(RXPromise *) createThreadWithUsers: (NSArray *) users name: (NSString *) name threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {
+    return [self createThreadWithUsers:users name:name image:nil thumbnail:nil threadCreated:threadCreated];
+}
+
 -(RXPromise *) createThreadWithUsers: (NSArray *) users threadCreated: (void(^)(NSError * error, id<PThread> thread)) threadCreated {
     return [self createThreadWithUsers:users name:nil threadCreated:threadCreated];
 }
-
 
 -(RXPromise *) addUsers: (NSArray *) users toThread: (id<PThread>) threadModel {
     

--- a/ChatSDKUI/Assets/ChatUILocalizable.strings
+++ b/ChatSDKUI/Assets/ChatUILocalizable.strings
@@ -38,6 +38,7 @@
 "bAdded" = "Added";
 "bAdd" = "Add";
 "bCreatingThread" = "Creating thread";
+"bUploadingImage" = "Uploading image";
 "bLogoutErrorTitle" = "Logout error";
 "bAuthenticating" = "Authenticating";
 

--- a/ChatSDKUI/Classes/Categories/NSBundle+ChatUI.h
+++ b/ChatSDKUI/Classes/Categories/NSBundle+ChatUI.h
@@ -49,6 +49,7 @@
 
 #define bAdd @"bAdd"
 #define bCreatingThread @"bCreatingThread"
+#define bUploadingImage @"bUploadingImage"
 #define bLogoutErrorTitle @"bLogoutErrorTitle"
 
 #define bSearch @"bSearch"

--- a/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
+++ b/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
@@ -362,7 +362,10 @@
     
     messageCell.navigationController = self.navigationController;
     
+    // Add a gradient to the cells
+    //float colorWeight = ((float) indexPath.row / (float) self.messages.count) * 0.15 + 0.85;
     float colorWeight = 1;
+    
     [messageCell setMessage:message withColorWeight:colorWeight];
     
     return messageCell;

--- a/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
+++ b/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
@@ -348,13 +348,21 @@
     
     BMessageCell<BMessageDelegate> * messageCell;
     
-    messageCell = [tableView_ dequeueReusableCellWithIdentifier:message.type.stringValue];
+    // We want to check if the message is a premium type but without the libraries added
+    // Without this check the app crashes if the user doesn't have premium cell types
+    if ((![BNetworkManager sharedManager].a.stickerMessage && message.type.integerValue == bMessageTypeSticker) ||
+        (![BNetworkManager sharedManager].a.videoMessage && message.type.integerValue == bMessageTypeVideo) ||
+        (![BNetworkManager sharedManager].a.audioMessage && message.type.integerValue == bMessageTypeAudio)) {
+        
+        messageCell = [tableView_ dequeueReusableCellWithIdentifier:@"0"];
+    }
+    else {
+        messageCell = [tableView_ dequeueReusableCellWithIdentifier:message.type.stringValue];
+    }
+    
     messageCell.navigationController = self.navigationController;
     
-    // Add a gradient to the cells
-    //float colorWeight = ((float) indexPath.row / (float) self.messages.count) * 0.15 + 0.85;
     float colorWeight = 1;
-    
     [messageCell setMessage:message withColorWeight:colorWeight];
     
     return messageCell;

--- a/ChatSDKUI/Classes/Components/Threads/BPrivateThreadsViewController.m
+++ b/ChatSDKUI/Classes/Components/Threads/BPrivateThreadsViewController.m
@@ -58,13 +58,14 @@
     BFriendsListViewController * flvc = (BFriendsListViewController *) [[BInterfaceManager sharedManager].a friendsViewControllerWithUsersToExclude:@[]];
     
     // The friends view controller will give us a list of users to invite
-    flvc.usersToInvite = ^(NSArray * users, NSString * groupName){
+    flvc.usersToInvite = ^(NSArray * users, NSString * groupName, NSString * imageUrl, NSString * thumbnailUrl) {
         
         MBProgressHUD * hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
         hud.label.text = [NSBundle t:bCreatingThread];
         
         // Create group with group name
-        [NM.core createThreadWithUsers:users name:groupName threadCreated:^(NSError *error, id<PThread> thread) {
+        [NM.core createThreadWithUsers:users name:groupName image:imageUrl thumbnail:thumbnailUrl threadCreated:^(NSError *error, id<PThread> thread) {
+            
             if (!error) {
                 [self pushChatViewControllerWithThread:thread];
             }

--- a/ChatSDKUI/Classes/Components/View Controllers/BFriendsListViewController.h
+++ b/ChatSDKUI/Classes/Components/View Controllers/BFriendsListViewController.h
@@ -10,6 +10,7 @@
 #import <MBProgressHUD/MBProgressHUD.h>
 #import <VENTokenField/VENTokenField.h>
 #import <ChatSDK/PThread_.h>
+#import <TOCropViewController/TOCropViewController.h>
 
 @class BSearchIndexViewController;
 @class MBProgressHUD;
@@ -22,17 +23,24 @@
 
 @end
 
-@interface BFriendsListViewController : UIViewController<UITableViewDataSource, UITableViewDelegate, VENTokenFieldDelegate, VENTokenFieldDataSource, UITextFieldDelegate> {
+@interface BFriendsListViewController : UIViewController<UITableViewDataSource, UITableViewDelegate, VENTokenFieldDelegate, VENTokenFieldDataSource, UITextFieldDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, TOCropViewControllerDelegate> {
+    
+    UIImagePickerController * _picker;
+    
     NSMutableArray * _contacts;
     NSMutableArray * _selectedContacts;
     NSMutableArray * _contactsToExclude;
     
     NSString * _filterByName;
     id _internetConnectionObserver;
+    
+    UIImage * groupImage;
 }
 
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, readwrite, copy) void (^usersToInvite)(NSArray * users, NSString * groupName);
+
+@property (nonatomic, readwrite, copy) void (^usersToInvite)(NSArray * users, NSString * groupName, NSString * imageUrl, NSString * thumbnailUrl);
+
 @property (nonatomic, readwrite) NSString * rightBarButtonActionTitle;
 @property (nonatomic, readwrite) NSArray * (^overrideContacts)();
 
@@ -41,6 +49,7 @@
 @property (weak, nonatomic) IBOutlet UIView * _tokenView;
 @property (weak, nonatomic) IBOutlet UITextField * groupNameTextField;
 @property (weak, nonatomic) IBOutlet UIView * groupNameView;
+@property (weak, nonatomic) IBOutlet UIButton * groupImageButton;
 
 @property (nonatomic, readwrite) int maximumSelectedUsers;
 

--- a/ChatSDKUI/Classes/Components/View Controllers/BFriendsListViewController.m
+++ b/ChatSDKUI/Classes/Components/View Controllers/BFriendsListViewController.m
@@ -154,25 +154,25 @@
         
         if (groupImage) {
             
+            [self.view endEditing:YES];
             MBProgressHUD * hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
-            [_tokenField resignFirstResponder];
-            hud.label.text = [NSBundle t:bCreatingThread];
+            hud.label.text = [NSBundle t:bUploadingImage];
             
             // Now reduce the image to 200x200 for the profile picture
             UIImage * image = [groupImage resizedImage:bProfilePictureSize interpolationQuality:kCGInterpolationHigh];
             UIImage * thumbnail = [groupImage resizedImage:bProfilePictureThumbnailSize interpolationQuality:kCGInterpolationHigh];
-            
+
             // Set the image now
             [NM.upload uploadImage:image thumbnail:thumbnail].thenOnMain(^id(NSDictionary * urls) {
-                
+
                 [MBProgressHUD hideHUDForView:self.view animated:YES];
-                
+
                 [self dismissViewControllerAnimated:YES completion:^{
                     if (self.usersToInvite != Nil) {
                         self.usersToInvite(_selectedContacts, groupNameTextField.text, urls[bImagePath], urls[bThumbnailPath]);
                     }
                 }];
-                
+
                 return urls;
             }, Nil);
         }

--- a/ChatSDKUI/Classes/Components/View Controllers/BUsersViewController.m
+++ b/ChatSDKUI/Classes/Components/View Controllers/BUsersViewController.m
@@ -181,7 +181,8 @@
         flvc.rightBarButtonActionTitle = [NSBundle t:bAdd];
         
         // The friends view controller will give us a list of users to invite
-        flvc.usersToInvite = ^(NSArray * users, NSString * groupName){
+        
+        flvc.usersToInvite = ^(NSArray * users, NSString * groupName, NSString * imageUrl, NSString * thumbnailUrl){
             
             [NM.core addUsers:users toThread:_thread].thenOnMain(^id(id success){
                 [UIView alertWithTitle:[NSBundle t:bSuccess] withMessage:[NSBundle t:bAdded]];

--- a/ChatSDKUI/Interface/BFriendsListViewController.xib
+++ b/ChatSDKUI/Interface/BFriendsListViewController.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2657" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,6 +14,7 @@
             <connections>
                 <outlet property="_tokenField" destination="UkR-FR-EHR" id="d3f-bH-zGs"/>
                 <outlet property="_tokenView" destination="Ok8-lm-Uad" id="DPB-kg-qqK"/>
+                <outlet property="groupImageButton" destination="Psm-Qh-uIE" id="ahw-gB-Fam"/>
                 <outlet property="groupNameTextField" destination="Lfx-uF-C6f" id="vWr-Ix-nxW"/>
                 <outlet property="groupNameView" destination="281-dx-DD4" id="Zd7-ch-Jrc"/>
                 <outlet property="tableView" destination="3eB-zr-9l2" id="3Uy-K9-6ll"/>
@@ -25,28 +27,48 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="281-dx-DD4">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="62"/>
                     <subviews>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Group Name" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lfx-uF-C6f">
-                            <rect key="frame" x="8" y="8" width="359" height="30"/>
+                            <rect key="frame" x="66" y="16" width="301" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="30" id="9zB-34-TpO"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                         </textField>
+                        <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Psm-Qh-uIE">
+                            <rect key="frame" x="4" y="4" width="54" height="54"/>
+                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="Psm-Qh-uIE" secondAttribute="height" id="7Rb-TV-3jd"/>
+                            </constraints>
+                            <state key="normal" title="Edit">
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="26"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="threadImageButtonPressed:" destination="-1" eventType="touchUpInside" id="pJO-jZ-4bf"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstAttribute="bottom" secondItem="Lfx-uF-C6f" secondAttribute="bottom" constant="8" id="2eB-mZ-Spc"/>
-                        <constraint firstItem="Lfx-uF-C6f" firstAttribute="leading" secondItem="281-dx-DD4" secondAttribute="leading" constant="8" id="4S2-Mp-z2Y"/>
-                        <constraint firstAttribute="height" constant="46" id="CEK-4p-SVa"/>
+                        <constraint firstAttribute="bottom" secondItem="Psm-Qh-uIE" secondAttribute="bottom" constant="4" id="6kM-Iz-b8C"/>
+                        <constraint firstAttribute="height" constant="62" id="CEK-4p-SVa"/>
                         <constraint firstAttribute="trailing" secondItem="Lfx-uF-C6f" secondAttribute="trailing" constant="8" id="GXo-Jw-Mfv"/>
-                        <constraint firstItem="Lfx-uF-C6f" firstAttribute="top" secondItem="281-dx-DD4" secondAttribute="top" constant="8" id="i1p-fC-W1z"/>
+                        <constraint firstItem="Lfx-uF-C6f" firstAttribute="centerY" secondItem="281-dx-DD4" secondAttribute="centerY" id="Kkj-kT-xil"/>
+                        <constraint firstItem="Psm-Qh-uIE" firstAttribute="top" secondItem="281-dx-DD4" secondAttribute="top" constant="4" id="OT9-We-MmK"/>
+                        <constraint firstItem="Psm-Qh-uIE" firstAttribute="leading" secondItem="281-dx-DD4" secondAttribute="leading" constant="4" id="SmX-F3-Tbm"/>
+                        <constraint firstItem="Lfx-uF-C6f" firstAttribute="leading" secondItem="Psm-Qh-uIE" secondAttribute="trailing" constant="8" id="kd6-IF-c1V"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ok8-lm-Uad">
-                    <rect key="frame" x="-1" y="46" width="377" height="44"/>
+                    <rect key="frame" x="-1" y="62" width="377" height="44"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UkR-FR-EHR" customClass="VENTokenField">
                             <rect key="frame" x="0.0" y="0.0" width="377" height="44"/>
@@ -64,7 +86,7 @@
                     </constraints>
                 </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="3eB-zr-9l2">
-                    <rect key="frame" x="0.0" y="90" width="375" height="577"/>
+                    <rect key="frame" x="0.0" y="106" width="375" height="561"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="g5S-wH-o6i"/>
@@ -88,9 +110,4 @@
             <point key="canvasLocation" x="-100.5" y="-91.5"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Xcode/ChatSDK Demo.xcodeproj/project.pbxproj
+++ b/Xcode/ChatSDK Demo.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
 				"${BUILT_PRODUCTS_DIR}/ChatSDK/ChatSDK.framework",
+				"${BUILT_PRODUCTS_DIR}/ChatSDKKeepLayout/KeepLayout.framework",
 				"${BUILT_PRODUCTS_DIR}/CountryPicker/CountryPicker.framework",
 				"${BUILT_PRODUCTS_DIR}/DateTools/DateTools.framework",
 				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
@@ -447,6 +448,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bolts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeepLayout.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CountryPicker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DateTools.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
@@ -479,8 +481,8 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ChatSDK Demo/Pods-ChatSDK Demo-resources.sh",
-				$PODS_CONFIGURATION_BUILD_DIR/FirebaseUI/FirebaseAuthUI.bundle,
-				$PODS_CONFIGURATION_BUILD_DIR/FirebaseUI/FirebasePhoneAuthUI.bundle,
+				"$PODS_CONFIGURATION_BUILD_DIR/FirebaseUI/FirebaseAuthUI.bundle",
+				"$PODS_CONFIGURATION_BUILD_DIR/FirebaseUI/FirebasePhoneAuthUI.bundle",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
 				"${PODS_ROOT}/TwitterKit/TwitterKit.framework/Versions/A/Resources/TwitterKitResources.bundle",
 			);

--- a/Xcode/ChatSDK Demo/Info.plist
+++ b/Xcode/ChatSDK Demo/Info.plist
@@ -119,7 +119,7 @@
 		<key>firebase</key>
 		<dict>
 			<key>root_path</key>
-			<string>all_features</string>
+			<string>test_123</string>
 			<key>cloud_messaging_server_key</key>
 			<string>AAAA_WvJyeI:APA91bFIDYoxnbFTub61SKCh8-RZrElzdkZpzyV3paGFlRWonMzq33zQmQW3ub5hDXLuRaipwtoHSoDKXkZlN5DRb_EYdrxtaDptmvZKCYBPKI-4RqTK9wVLOJvgc5X3bVWLfpNSJO_tLK2pnmhfpHDw2Zs-5L2yug</string>
 		</dict>

--- a/Xcode/ChatSDK Demo/SyncData/BSyncDataFetcher.m
+++ b/Xcode/ChatSDK Demo/SyncData/BSyncDataFetcher.m
@@ -10,7 +10,8 @@
 
 #import <ChatSDK/ChatCore.h>
 #import "ChatFirebaseAdapter.h"
-#import "SyncData.h"
+#import "BSyncItem.h"
+#import "BSyncDataListener.h"
 
 @implementation BSyncDataFetcher
 

--- a/Xcode/ChatSDK Demo/SyncData/BSyncItem.m
+++ b/Xcode/ChatSDK Demo/SyncData/BSyncItem.m
@@ -34,10 +34,10 @@
 
 -(FIRDatabaseReference *) ref {
     if(_entityID) {
-        return [[[[FIRDatabaseReference firebaseRef] child: bBaseDataPath] child:[self getPath]] child:_entityID];
+        return [[[[FIRDatabaseReference firebaseRef] child: bBaseDataPath] child:[self path]] child:_entityID];
     }
     else {
-        FIRDatabaseReference * ref = [[[[FIRDatabaseReference firebaseRef] child: bBaseDataPath] child:[self getPath]] childByAutoId];
+        FIRDatabaseReference * ref = [[[[FIRDatabaseReference firebaseRef] child: bBaseDataPath] child:[self path]] childByAutoId];
         _entityID = ref.key;
         return ref;
     }


### PR DESCRIPTION
Private thread groups can now have an image set for them
Load up and select more than one contact. This reveals an image button next to the group name textField. We can then set this and it uploads as meta data for the thread. This requires a new createThread function where we pass the url of the image and thumbnail.
