### PR TITLE
Critical security issue in rules.json

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,8 +1,5 @@
 {
   "rules": {
-        
-    ".read": "auth != null",
-    ".write": "auth != null",
     
     "$root": {
       


### PR DESCRIPTION
Shallow rules override deep rules in Firebase, so these two lines essentially allow any logged in user to read/write from/to any location in the database.

> Note: Shallower security rules override rules at deeper paths. Child rules can only grant additional privileges to what parent nodes have already declared. They cannot revoke a read or write privilege.

from https://firebase.google.com/docs/database/security/securing-data