### PR TITLE
Create handleUserResult callback

### DIFF
--- a/ChatSDKFirebase/FirebaseNetworkAdapter/Classes/Handlers/BFirebaseAuthenticationHandler.m
+++ b/ChatSDKFirebase/FirebaseNetworkAdapter/Classes/Handlers/BFirebaseAuthenticationHandler.m
@@ -96,7 +96,16 @@
             [promise rejectWithReason:error];
         }
     };
-    
+
+    void(^handleUserResult)(FIRUser * user, NSError *error) = ^(FIRUser * _Nullable user, NSError * _Nullable error) {
+        if (!error) {
+            [promise resolveWithResult:user];
+        }
+        else {
+            [promise rejectWithReason:error];
+        }
+    };
+
     promise = promise.thenOnMain(^id(FIRUser * firebaseUser) {
         return [self loginWithFirebaseUser: firebaseUser accountDetails:details];
     }, Nil);
@@ -153,19 +162,19 @@
             break;
         case bAccountTypeUsername:
         {
-            [[FIRAuth auth] signInWithEmail:details.username password:details.password completion:handleResult];
+            [[FIRAuth auth] signInWithEmail:details.username password:details.password completion:handleUserResult];
         }
             break;
         case bAccountTypeCustom:
-            [[FIRAuth auth] signInWithCustomToken:details.token completion:handleResult];
+            [[FIRAuth auth] signInWithCustomToken:details.token completion:handleUserResult];
             break;
         case bAccountTypeRegister:
         {
-            [[FIRAuth auth] createUserWithEmail:details.username password:details.password completion:handleResult];
+            [[FIRAuth auth] createUserWithEmail:details.username password:details.password completion:handleUserResult];
         }
             break;
         case bAccountTypeAnonymous: {
-            [[FIRAuth auth] signInAnonymouslyWithCompletion:handleResult];
+            [[FIRAuth auth] signInAnonymouslyWithCompletion:handleUserResult];
         }
             break;
         default:


### PR DESCRIPTION
The new version of Firebase has some [breaking changes](https://firebase.google.com/support/release-notes/ios#authentication_53).

> Added `FIRAuthDataResultCallback`, which returns an `AuthDataResult` object instead of a `User` object after sign-in. This replaces `FIRAuthResultCallback` for the following methods: `signInWithEmail:`, `signInwithCredential:`, `signInAnonymouslyWithCompletion:`, and `createUserWithEmail:`.

This pull request adds a `handleUserResult` callback which is a modified version of the `handleResult` callback with updated parameters.