### PR TITLE
Allowed for generic chat controller

### DIFF
--- a/ChatSDKCore/Classes/Interfaces/PInterfaceAdapter.h
+++ b/ChatSDKCore/Classes/Interfaces/PInterfaceAdapter.h
@@ -64,7 +64,7 @@
 -(UINavigationController *) friendsNavigationControllerWithUsersToExclude: (NSArray *) usersToExclude onComplete: (void(^)(NSArray * users, NSString * name)) action;
 
 -(void) setChatViewController: (BChatViewController * (^)(id<PThread> thread)) provider;
--(BChatViewController *) chatViewControllerWithThread: (id<PThread>) thread;
+-(UIViewController *) chatViewControllerWithThread: (id<PThread>) thread;
 
 -(NSArray *) defaultTabBarViewControllers;
 -(UIView<PSendBar> *) sendBarView;

--- a/ChatSDKUI/Classes/Manager/BDefaultInterfaceAdapter.m
+++ b/ChatSDKUI/Classes/Manager/BDefaultInterfaceAdapter.m
@@ -148,7 +148,7 @@
     return [self termsOfServiceNavigationController];
 }
 
--(BChatViewController *) chatViewControllerWithThread: (id<PThread>) thread {
+-(UIViewController *) chatViewControllerWithThread: (id<PThread>) thread {
     if (_chatViewController != Nil) {
         return _chatViewController(thread);
     }


### PR DESCRIPTION
I want to customize the chat detail to embed the chat list into a parent controller that will contain some extra views. The `BChatViewController` does not allow me to use a custom storyboard, so I decided to implement a compoisiton where the chat list is a child controller. However, the Interface adapter requires a `BChatViewController` subclass, which does not allow for this.

I have removed the explicit type to a generic `UIViewController` since there is no usage of the `BChatViewController` directly (at least not within the code I have, without plugins)