### PR TITLE
Fixed layout issue with iPhone XR

### DIFF
--- a/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
+++ b/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
@@ -725,10 +725,9 @@
 }
 
 -(float) textInputViewBottomInset {
-    // Fix for the iPhone X
     // Move the text input up to avoid the bottom area
-    if([UIScreen mainScreen].nativeBounds.size.height == 2436) {
-        return 30;
+    if (@available(iOS 11, *)) {
+        return self.view.safeAreaInsets.bottom;
     }
     return 0;
 }


### PR DESCRIPTION
There was an "ungly" device height check to add extra bottom spacing on the chat controller. However, the hardcoded size is only valid for iPhone X and not the new devices like iPhone XR or iPhone XS Max.  
Instead of hardcoding the device height and margin, just use the native `safeAreaInsets` property