### PR TITLE
Add customization for time label's color

### DIFF
--- a/ChatSDKCore/Classes/Defines/BCoreDefines.h
+++ b/ChatSDKCore/Classes/Defines/BCoreDefines.h
@@ -18,6 +18,7 @@
 
 #define bDefaultMessageColorMe @"abcff4"
 #define bDefaultMessageColorReply @"d7d4d3"
+#define bDefaultMessageColorTime @"aaaaaa"
 
 #define bDefaultProfileImage @"icn_100_anonymous.png"
 #define bDefaultPublicGroupImage @"icn_100_anonymous_group.png"

--- a/ChatSDKCore/Classes/Session/BConfiguration.h
+++ b/ChatSDKCore/Classes/Session/BConfiguration.h
@@ -165,6 +165,9 @@ typedef enum {
 @property (nonatomic, readwrite) UIFont * messageTimeFont;
 @property (nonatomic, readwrite) UIFont * messageNameFont;
 
+/// Set the custom color of the time label. If not set, it will use the default color of time label.
+@property (nonatomic, readwrite) NSString * messageTimeColor;
+
 @property (nonatomic, readwrite) UIFont * threadTitleFont;
 @property (nonatomic, readwrite) UIFont * threadTimeFont;
 @property (nonatomic, readwrite) UIFont * threadSubtitleFont;

--- a/ChatSDKCore/Classes/Session/BConfiguration.m
+++ b/ChatSDKCore/Classes/Session/BConfiguration.m
@@ -13,6 +13,7 @@
 
 @synthesize messageColorMe;
 @synthesize messageColorReply;
+@synthesize messageTimeColor;
 @synthesize rootPath;
 @synthesize appBadgeEnabled;
 @synthesize defaultUserNamePrefix;

--- a/ChatSDKUI/Classes/Components/Message Cells/BMessageCell.m
+++ b/ChatSDKUI/Classes/Components/Message Cells/BMessageCell.m
@@ -49,7 +49,11 @@
             _timeLabel.font = BChatSDK.config.messageTimeFont;
         }
 
-        _timeLabel.textColor = [UIColor lightGrayColor];
+        _timeLabel.textColor = [BCoreUtilities colorWithHexString:bDefaultMessageColorTime];
+        if(BChatSDK.config.messageTimeColor) {
+            _timeLabel.textColor = [BCoreUtilities colorWithHexString:BChatSDK.config.messageTimeColor];
+        }
+        
         _timeLabel.userInteractionEnabled = NO;
         
         [self.contentView addSubview:_timeLabel];


### PR DESCRIPTION
Set the custom color of the time label. If not set, it will use the default color (#aaaaaa) of time label.