### PR TITLE
Add customization for chat screen's background color

### DIFF
--- a/ChatSDKCore/Classes/Defines/BCoreDefines.h
+++ b/ChatSDKCore/Classes/Defines/BCoreDefines.h
@@ -16,6 +16,8 @@
 #define bTypingTimeout 5.0
 #define bLocationDefaultArea 1000
 
+#define bDefaultChatBgColor @"ffffff"
+
 #define bDefaultMessageColorMe @"abcff4"
 #define bDefaultMessageColorReply @"d7d4d3"
 

--- a/ChatSDKCore/Classes/Session/BConfiguration.h
+++ b/ChatSDKCore/Classes/Session/BConfiguration.h
@@ -31,6 +31,10 @@ typedef enum {
 
 // Should we ask the user to allow notifications when the app initially loads up? 
 @property (nonatomic, readwrite) BOOL shouldAskForNotificationsPermission;
+
+/// Custom background color of BChatViewController's main view.
+@property (nonatomic, readwrite) NSString * chatBgColor;
+
     
 // Background color of messages: hex value like "FFFFFF"
 @property (nonatomic, readwrite) NSString * messageColorMe;

--- a/ChatSDKCore/Classes/Session/BConfiguration.m
+++ b/ChatSDKCore/Classes/Session/BConfiguration.m
@@ -11,6 +11,7 @@
 
 @implementation BConfiguration
 
+@synthesize chatBgColor;
 @synthesize messageColorMe;
 @synthesize messageColorReply;
 @synthesize rootPath;

--- a/ChatSDKUI/Classes/Components/Chat View/BChatViewController.m
+++ b/ChatSDKUI/Classes/Components/Chat View/BChatViewController.m
@@ -30,6 +30,11 @@
 -(void) viewDidLoad {
     [super viewDidLoad];
     
+    self.view.backgroundColor = [BCoreUtilities colorWithHexString:bDefaultChatBgColor];
+    if(BChatSDK.config.chatBgColor) {
+        self.view.backgroundColor = [BCoreUtilities colorWithHexString:BChatSDK.config.chatBgColor];
+    }
+    
     [_sendBarView setMaxLines:BChatSDK.config.textInputViewMaxLines];
     [_sendBarView setMaxCharacters:BChatSDK.config.textInputViewMaxCharacters];
 

--- a/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
+++ b/ChatSDKUI/Classes/Components/SDK/ElmChatViewController.m
@@ -46,6 +46,10 @@
         _tapRecognizer.enabled = NO;
         [self.view addGestureRecognizer:_tapRecognizer];
         
+        if (BChatSDK.config.chatBgColor) {
+            self.tableView.backgroundColor = [BCoreUtilities colorWithHexString:BChatSDK.config.chatBgColor];
+        }
+        
         // When a user taps the title bar we want to know to show the options screen
         if (BChatSDK.config.userChatInfoEnabled) {
             UITapGestureRecognizer * titleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(navigationBarTapped)];


### PR DESCRIPTION
Custom background color of BChatViewController's main view. If not set, it will use the default color (#ffffff).