### PR TITLE
fix duplicate bto macro definition

### DIFF
--- a/ChatSDKCore/Classes/Defines/BKeys.h
+++ b/ChatSDKCore/Classes/Defines/BKeys.h
@@ -31,7 +31,7 @@
 #define bDate @"date"
 #define bUserFirebaseID @"user-firebase-id"
 #define bFrom @"from"
-#define bTo @"to"
+//#define bTo @"to"
 
 #define bMute @"mute"
 #define bUnmute @"unmute"


### PR DESCRIPTION
Removed duplicate `bTo` macro as it was throwing duplicate definition error. 