### PR TITLE
Call didReceiveRemoteNotification in case when app is in forground

### DIFF
--- a/ChatSDKCore/Classes/Push/BLocalNotificationDelegate.m
+++ b/ChatSDKCore/Classes/Push/BLocalNotificationDelegate.m
@@ -38,6 +38,8 @@
     
     if (showLocalNotification) {
         completionHandler(UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound | UNNotificationPresentationOptionAlert);
+    } else {
+        [BChatSDK application:[UIApplication sharedApplication] didReceiveRemoteNotification:notification.request.content.userInfo];
     }
 }
 


### PR DESCRIPTION
Removed duplicate `bTo` macro as it was throwing duplicate definition error. 