### PR TITLE
Issue: Only 1 thread has owner, previous threads get owner nulled on adding new

### DIFF
--- a/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/.xccurrentversion
+++ b/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>DataModel v019.xcdatamodel</string>
+	<string>DataModel v020.xcdatamodel</string>
 </dict>
 </plist>

--- a/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/DataModel v019.xcdatamodel/contents
+++ b/ChatSDKCoreData/Assets/ChatSDK.xcdatamodeld/DataModel v019.xcdatamodel/contents
@@ -40,7 +40,7 @@
         <relationship name="linkedAccounts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUserAccount" inverseName="user" inverseEntity="CDUserAccount" syncable="YES"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDMessage" inverseName="user" inverseEntity="CDMessage" syncable="YES"/>
         <relationship name="threads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDThread" inverseName="users" inverseEntity="CDThread" syncable="YES"/>
-        <relationship name="threadsCreated" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDThread" inverseName="creator" inverseEntity="CDThread" syncable="YES"/>
+        <relationship name="threadsCreated" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDThread" inverseName="creator" inverseEntity="CDThread" syncable="YES"/>
         <relationship name="userConnections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDUserConnection" inverseName="owner" inverseEntity="CDUserConnection" syncable="YES"/>
     </entity>
     <entity name="CDUserAccount" representedClassName="CDUserAccount" syncable="YES">


### PR DESCRIPTION
Issue: Only 1 thread has owner, previous threads get owner field set to null 

Solution 1: change relation from "Single" to "To many" of threadsCreated for CDUser entity in xcdatamodel v19
Soultion 2: use xcdatamodel v20 (as it does not have "threadsCreated" property)