### PR TITLE
Avoid unnecessary sorting

### DIFF
--- a/ChatSDKCoreData/Classes/Entities/CDThread.m
+++ b/ChatSDKCoreData/Classes/Entities/CDThread.m
@@ -43,7 +43,7 @@
 
 -(BOOL) hasMessages {
     [self checkOnMain];
-    return self.newestMessage != Nil;
+	return (self.messages.count > 0);
 }
 
 -(void) addMessage: (id<PMessage>) theMessage {


### PR DESCRIPTION
There are some major performance issues around fetching threads and checking if a thread has messages due to sorting. If an app e.g. asks for a specific thread and doing it multiple times, each time there is a sorting involved. Sometimes sorting is not needed at all, e.g. when fetching by a user id or checking if the thread has messages. 

This PR tries to solve the issue of sorting all messages before checking if there is a message in a thread by just checking if the messages array has elements in it.

The contributor licensing agreement has not yet been signed. I plan to do it later.