### PR TITLE
Bumped versions of dependencies and also set target ios17

### DIFF
--- a/ChatK!t.podspec
+++ b/ChatK!t.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/chat-sdk/chat-sdk-ios.git", :tag => s.version.to_s }
   s.module_name      = 'ChatKit'
 
-  s.platform     = :ios, '13.0'
+  s.platform     = :ios, '17.0'
   s.requires_arc = true
   s.swift_version = "5.0"
   s.default_subspec = 'ChatK!t'
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     s.dependency 'MZDownloadManager'
     s.dependency 'FLAnimatedImage'
     s.dependency 'GSImageViewerController'
-    s.dependency 'RxSwift', '~>6.2.0'
+    s.dependency 'RxSwift', '~>6.9.0'
     s.dependency 'DateTools'
     s.dependency 'SDWebImage'
     s.dependency 'ZLImageEditor'

--- a/ChatSDK.podspec
+++ b/ChatSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/chat-sdk/chat-sdk-ios.git", :tag => s.version.to_s }
   s.module_name      = 'ChatSDK'
 
-  s.platform     = :ios, '11.0'
+  s.platform     = :ios, '17.0'
   s.requires_arc = true
   s.swift_version = "5.0"
   # s.static_framework = true
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
 	  s.dependency 'DateTools', '~> 2.0'
       s.dependency 'SAMKeychain'
 
-      s.dependency 'RxSwift', '~>6.2.0'
-      s.dependency 'RxCocoa', '~>6.2.0'
+      s.dependency 'RxSwift', '~>6.9.0'
+      s.dependency 'RxCocoa', '~>6.9.0'
 
       s.frameworks = 'SafariServices'
   
@@ -70,14 +70,14 @@ Pod::Spec.new do |s|
 		'ChatUI' => ['ChatSDKUI/Assets/**/*', 'ChatSDKUI/Interface/**/*']
 	  }
 			
-	  s.dependency 'MBProgressHUD', '~> 1.2.0'
+	  s.dependency 'MBProgressHUD'
 	  s.dependency 'VENTokenField', '~> 2.0'
 	  s.dependency 'SDWebImage', '~> 5.0'
 	  s.dependency 'StaticDataTableViewController', '~> 2.0'
 	  s.dependency 'CropViewController', '~> 2.0'
 	  s.dependency 'Hakawai', '~> 5.1.5'
 	  s.dependency 'ChatSDKKeepLayout'
-	  s.dependency 'Toast', '~>4.0.0'
+	  s.dependency 'Toast', '~>4.1.1'
 	  s.dependency 'EFQRCode'
 	  s.dependency 'CollectionKit'
     s.dependency 'QuickTableViewController'	  

--- a/ChatSDKFirebase.podspec
+++ b/ChatSDKFirebase.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/chat-sdk/chat-sdk-ios.git", :tag => s.version.to_s }
 #   s.module_name      = 'ChatSDKFirebase'
 
-  s.platform     = :ios, '11.0'
+  s.platform     = :ios, '17.0'
   s.requires_arc = true
   s.swift_version = "5.0"
   # s.static_framework = true


### PR DESCRIPTION
Bumped versions of dependencies to fight against the PrivacyInfo manifest (RxSwift 6.9.0, RxCocoa 6.9.0, RxRelay 6.9.0, Toast 4.1.1). For MBProgressHUD, it has to be via Podfile with the latest commit, as suggested in https://github.com/jdg/MBProgressHUD/issues/664

Also, changed to minimum target ios 17, if this doesn't suit the project's needs please feel free to lower the version.